### PR TITLE
fix: treat emails as case-insensitive like the Grafana API

### DIFF
--- a/internal/controller/organization/organization.go
+++ b/internal/controller/organization/organization.go
@@ -379,18 +379,23 @@ func (c *external) updateUsers(cr *v1alpha1.Organization, actual v1alpha1.Organi
 }
 
 func mapUsers(p v1alpha1.OrganizationParameters) map[string]OrgUser {
+	var normalizedMail string
 	users := make(map[string]OrgUser)
 	for _, email := range p.Admins {
-		users[*email] = OrgUser{Email: *email, Role: "Admin"}
+		normalizedMail = strings.ToLower(*email)
+		users[normalizedMail] = OrgUser{Email: normalizedMail, Role: "Admin"}
 	}
 	for _, email := range p.Editors {
-		users[*email] = OrgUser{Email: *email, Role: "Editor"}
+		normalizedMail = strings.ToLower(*email)
+		users[normalizedMail] = OrgUser{Email: normalizedMail, Role: "Editor"}
 	}
 	for _, email := range p.Viewers {
-		users[*email] = OrgUser{Email: *email, Role: "Viewer"}
+		normalizedMail = strings.ToLower(*email)
+		users[normalizedMail] = OrgUser{Email: normalizedMail, Role: "Viewer"}
 	}
 	for _, email := range p.UsersWithoutAccess {
-		users[*email] = OrgUser{Email: *email, Role: "None"}
+		normalizedMail = strings.ToLower(*email)
+		users[normalizedMail] = OrgUser{Email: normalizedMail, Role: "None"}
 	}
 	return users
 }


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

The E-Mails of users are treated as case-insensitive by Grafana, therefore creating a user `a@domain.com` and `A@domain.com` will result in 

```
message: 'update failed: cannot update user: [POST /admin/users][412] adminCreateUserPreconditionFailed
        {"message":"User with email ''a@domain.com'' or username ''a@domain.com' already exists"}'
```

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~~Added `backport release-x.y` labels to auto-backport this PR if necessary.~~

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
